### PR TITLE
Miscellaneous updates

### DIFF
--- a/mkdocs/docs/glossary/index.md
+++ b/mkdocs/docs/glossary/index.md
@@ -34,6 +34,10 @@
 **ACES Viewing Transform**
 : Combined RRT and ACES Output Device Transform.
 
+**American Society of Cinematographers Color Decision List**
+**ASC CDL**
+: A set of file formats for the exchange of basic primary color grading information between equipment and software from different manufacturers. ASC CDL provides for Slope, Offset and Power operations applied to each of the red, green and blue channels and for an overall Saturation operation affecting all three.
+
 ## B
 
 ## C

--- a/mkdocs/docs/index.md
+++ b/mkdocs/docs/index.md
@@ -103,19 +103,19 @@ SMPTE Standards   {#smpte}
 
 Below are the ACES-related standards documents published through SMPTE to date. Those wishing to implement ACES should adhere to the SMPTE standards. These must be purchased in order to view.
 
-### [:fontawesome-solid-file:{ .icons } SMPTE ST 2065-1 - Academy Color Encoding Specification](https://ieeexplore.ieee.org/servlet/opac?punumber=7289893) 
+### [:fontawesome-solid-file:{ .icons } SMPTE ST 2065-1 - Academy Color Encoding Specification](https://doi.org/10.5594/SMPTE.ST2065-1.2021)
 
-### [:fontawesome-solid-file:{ .icons } SMPTE ST 2065-2 - Academy Printing Density (APD) — Spectral Responsivities, Reference Measurement Device and Spectral Calculation](https://ieeexplore.ieee.org/servlet/opac?punumber=7292041) 
+### [:fontawesome-solid-file:{ .icons } SMPTE ST 2065-2 - Academy Printing Density (APD) — Spectral Responsivities, Reference Measurement Device and Spectral Calculation](https://doi.org/10.5594/SMPTE.ST2065-2.2020)
 
-### [:fontawesome-solid-file:{ .icons } SMPTE ST 2065-3 - Academy Density Exchange Encoding (ADX) — Encoding Academy Printing Density (APD) Values](https://ieeexplore.ieee.org/servlet/opac?punumber=7291492) 
+### [:fontawesome-solid-file:{ .icons } SMPTE ST 2065-3 - Academy Density Exchange Encoding (ADX) — Encoding Academy Printing Density (APD) Values](https://doi.org/10.5594/SMPTE.ST2065-3.2020)
 
-### [:fontawesome-solid-file:{ .icons } SMPTE ST 2065-4 - ACES Image Container File Layout](https://ieeexplore.ieee.org/servlet/opac?punumber=7290439) 
+### [:fontawesome-solid-file:{ .icons } SMPTE ST 2065-4 - ACES Image Container File Layout](https://doi.org/10.5594/SMPTE.ST2065-4.2013)
 
-### [:fontawesome-solid-file:{ .icons } SMPTE ST 2065-5 - Material Exchange Format — Mapping ACES Image Sequences into the MXF Generic Container](https://ieeexplore.ieee.org/servlet/opac?punumber=7748436) 
+### [:fontawesome-solid-file:{ .icons } SMPTE ST 2065-5 - Material Exchange Format — Mapping ACES Image Sequences into the MXF Generic Container](https://doi.org/10.5594/SMPTE.ST2065-5.2016)
 
-### [:fontawesome-solid-file:{ .icons } SMPTE ST 2067-50 - SMPTE Standard - Interoperable Master Format — Application #5 ACES](https://ieeexplore.ieee.org/document/8320049)
+### [:fontawesome-solid-file:{ .icons } SMPTE ST 2067-50 - SMPTE Standard - Interoperable Master Format — Application #5 ACES](https://doi.org/10.5594/SMPTE.ST2067-50.2018)
 
-### [:fontawesome-solid-file:{ .icons } SMPTE ST 268:2014 – File Format for Digital Moving Picture Exchange (DPX) – Amendment 1](https://ieeexplore.ieee.org/servlet/opac?punumber=7291018) 
+### [:fontawesome-solid-file:{ .icons } SMPTE ST 268:2014 – File Format for Digital Moving Picture Exchange (DPX) – Amendment 1](https://doi.org/10.5594/SMPTE.ST268.2003Am1.2012)
 
 
 <!-- Page specific styles -->

--- a/mkdocs/docs/index.md
+++ b/mkdocs/docs/index.md
@@ -55,7 +55,7 @@ ACES Encodings
 Specifies ACES, the fundamental colorimetric encoding in the Academy Color Encoding System.
 *See SMPTE 2065-1*
 
-### :fontawesome-solid-file-contract:{ .icons } [ACEScct](http://j.mp/S-2016-001_)
+### :fontawesome-solid-file-contract:{ .icons } [ACEScct](/specifications/acescct/)
 Defines a logarithmic colorimetric encoding more appropriate for legacy color correction operators.
 
 ### :fontawesome-solid-file-contract:{ .icons } [ACEScg](http://j.mp/S-2014-004)

--- a/mkdocs/docs/index.md
+++ b/mkdocs/docs/index.md
@@ -4,67 +4,74 @@ ACES Documentation
 System Documentation
 ----------------
 
-### :fontawesome-solid-arrow-down-wide-short:{ .icons } [Project Organization and Development Procedure](https://aces.mp/P-2019_001)
+### [:fontawesome-solid-arrow-down-wide-short:{ .icons } Project Organization and Development Procedure](https://aces.mp/P-2019_001)
 Provides details on the organizational and decision making structure to be used in the development of the ACES.
 
-### :fontawesome-solid-arrow-down-1-9:{ .icons } [Versioning System](http://j.mp/S-2014-002)
+### [:fontawesome-solid-arrow-down-1-9:{ .icons } Versioning System](http://j.mp/S-2014-002)
 Describes versioning numbers and format of TransformIDs for components the ACES system.
 
-### :fontawesome-solid-arrow-down-a-z:{ .icons } [Component Names](http://j.mp/TB-2014-012)
-Describes preferred terminology for key ACES component names for ACES 1.0.
-
-### :fontawesome-solid-file-export:{ .icons } [Input Transforms (IDTs)](http://j.mp/P-2013-001)
-Describes methods to create Input Transforms (IDTs) for use within ACES.
-
-### :fontawesome-solid-fill-drip:{ .icons } [Look Modification Transforms](http://j.mp/TB-2014-010)
-Describes the design, integration and use of Look Modification Transforms.
-
-### :material-arrow-collapse:{ .icons } [Reference Gamut Compression User Guide](guides/rgc-user/) :material-new-box:{ .new-icons }
-Describes suggested user workflows for on set, dailies, visual effects, and finishing using the ACES Reference Gamut Compression (RGC)
-
-### :fontawesome-solid-file-code:{ .icons } [Reference Gamut Compression Implementation Guide](guides/rgc-implementation/) :material-new-box:{ .new-icons }
-Implementation guidelines related to the usage of the Reference Gamut Compression.
-
-### :fontawesome-solid-desktop:{ .icons } [UX Guidelines](http://j.mp/TB-2014-002)
+### [:fontawesome-solid-desktop:{ .icons } UX Guidelines](http://j.mp/TB-2014-002)
 Provides guidelines on how best to present ACES terminology and concepts within products to end-users.
 
-### :fontawesome-solid-file-code:{ .icons } [Common LUT Format Specification](specifications/clf/)
-Specifies a flexible XML-based file format for color Look-Up Tables (LUTs) and other basic image operators.
-
-### :fontawesome-solid-file-code:{ .icons } [Common LUT Format Implementation Guide](guides/clf/) :material-new-box:{ .new-icons }
-Implementation guidelines related to the usage of the Common LUT Format.
-
-### :fontawesome-solid-file-code:{ .icons } [ACES Metadata File Specification](https://aces.mp/S-2019-001)
-Specifies a ‘sidecar’ XML file intended to exchange the metadata required to recreate ACES viewing pipelines.
-
-### :fontawesome-solid-file-code:{ .icons } [ACES Metadata File Implementation Guidelines and Best Practices](guides/amf/) :material-new-box:{ .new-icons }
-Implementation guidelines and best practices related to the usage of the ACES Metadata File (AMF) in various workflows
-
-### :fontawesome-solid-glasses:{ .icons } [Alternate Viewing Pipeline](http://j.mp/TB-2014-013)
+### [:fontawesome-solid-glasses:{ .icons } Alternate Viewing Pipeline](http://j.mp/TB-2014-013)
 Describes an alternate approach to implementing and presenting the ACES viewing pipeline.
 
-### :fontawesome-solid-file-arrow-down:{ .icons } [ACES White Point Derivation](http://j.mp/TB-2018-001)
+### [:fontawesome-solid-file-arrow-down:{ .icons } ACES White Point Derivation](http://j.mp/TB-2018-001)
 Describes the derivation of the ACES white point and why the chromaticity coordinates were chosen.
+
+
+--------------
+
+System Components
+----------------
+
+### [:fontawesome-solid-arrow-down-a-z:{ .icons } Component Names](http://j.mp/TB-2014-012)
+Describes preferred terminology for key ACES component names for ACES 1.0.
+
+### [:fontawesome-solid-file-export:{ .icons } Input Transforms (IDTs)](http://j.mp/P-2013-001)
+Describes methods to create Input Transforms (IDTs) for use within ACES.
+
+### [:fontawesome-solid-fill-drip:{ .icons } Look Modification Transforms](http://j.mp/TB-2014-010)
+Describes the design, integration and use of Look Modification Transforms.
+
+### [:material-arrow-collapse:{ .icons } Reference Gamut Compression User Guide](guides/rgc-user/) :material-new-box:{ .new-icons }
+Describes suggested user workflows for on set, dailies, visual effects, and finishing using the ACES Reference Gamut Compression (RGC)
+
+### [:fontawesome-solid-file-code:{ .icons } Reference Gamut Compression Implementation Guide](guides/rgc-implementation/) :material-new-box:{ .new-icons }
+Implementation guidelines related to the usage of the Reference Gamut Compression.
+
+### [:fontawesome-solid-file-code:{ .icons } Common LUT Format (CLF) Specification](specifications/clf/)
+Specifies a flexible XML-based file format for color Look-Up Tables (LUTs) and other basic image operators.
+
+### [:fontawesome-solid-file-code:{ .icons } Common LUT Format (CLF) Implementation Guide](guides/clf/) :material-new-box:{ .new-icons }
+Implementation guidelines related to the usage of the Common LUT Format.
+
+### [:fontawesome-solid-file-code:{ .icons } ACES Metadata File (AMF) Specification](https://aces.mp/S-2019-001)
+Specifies a ‘sidecar’ XML file intended to exchange the metadata required to recreate ACES viewing pipelines.
+
+### [:fontawesome-solid-file-code:{ .icons } ACES Metadata File (AMF) Implementation Guidelines and Best Practices](guides/amf/) :material-new-box:{ .new-icons }
+Implementation guidelines and best practices related to the usage of the ACES Metadata File (AMF) in various workflows
+
 
 ----------------
 
 ACES Encodings
 ----------------
 
-### :fontawesome-solid-file-contract:{ .icons } [ACES 2065-1](http://j.mp/TB-2014-004)
+### [:fontawesome-solid-file-contract:{ .icons } ACES 2065-1](http://j.mp/TB-2014-004)
 Specifies ACES, the fundamental colorimetric encoding in the Academy Color Encoding System.
 *See SMPTE 2065-1*
 
-### :fontawesome-solid-file-contract:{ .icons } [ACEScct](/specifications/acescct/)
+### [:fontawesome-solid-file-contract:{ .icons } ACEScct](/specifications/acescct/)
 Defines a logarithmic colorimetric encoding more appropriate for legacy color correction operators.
 
-### :fontawesome-solid-file-contract:{ .icons } [ACEScg](http://j.mp/S-2014-004)
+### [:fontawesome-solid-file-contract:{ .icons } ACEScg](http://j.mp/S-2014-004)
 Defines a colorimetric encoding appropriate as a working space for use in CGI tools such as compositors, paint and rendering systems.
 
-### :fontawesome-solid-file-contract:{ .icons } [ACEScc](http://j.mp/S-2014-003)
+### [:fontawesome-solid-file-contract:{ .icons } ACEScc](http://j.mp/S-2014-003)
 Defines a logarithmic colorimetric encoding appropriate for legacy color correction operators.
 
-### :fontawesome-solid-file-contract:{ .icons } [ACESproxy](http://j.mp/S-2013-001)
+### [:fontawesome-solid-file-contract:{ .icons } ACESproxy](http://j.mp/S-2013-001)
 Defines an integer logarithmic colorimetric encoding appropriate for on-set preview and on-set look management applications.
 
 ----------------
@@ -72,49 +79,44 @@ Defines an integer logarithmic colorimetric encoding appropriate for on-set prev
 Informative Notes (legacy documents)
 ----------------
 
+SMPTE standards supercede these legacy documents and links to purchase the standards are included in the [next section](#smpte).
+
 Some informative notes on some of the ACES-related SMPTE standards are provided via Technical Bulletins. In most cases, these include the original Academy documents that were modified into the SMPTE standards documents.
 
-The SMPTE standards supercede these documents and links to purchase the standards are included in the next section.
 
-### :fontawesome-solid-circle-info:{ .icons } [Academy Color Encoding Specification (ACES)](http://j.mp/TB-2014-006)
+### [:fontawesome-solid-circle-info:{ .icons } Academy Color Encoding Specification (ACES)](http://j.mp/TB-2014-006)
 Provides background and contextual information on SMPTE ST 2065-1:2012.
 
-### :fontawesome-solid-circle-info:{ .icons } [ACES Image Container File (OpenEXR)](http://j.mp/TB-2014-006)
+### [:fontawesome-solid-circle-info:{ .icons } ACES Image Container File (OpenEXR)](http://j.mp/TB-2014-006)
 Provides background and contextual information on SMPTE ST 2065-4:2013.
 
-### :fontawesome-solid-circle-info:{ .icons } [ADX Image Container File (DPX)](http://j.mp/TB-2014-007)
+### [:fontawesome-solid-circle-info:{ .icons } ADX Image Container File (DPX)](http://j.mp/TB-2014-007)
 Provides background and contextual information on SMPTE ST 268:2003 Am1:2012.
 
-### :fontawesome-solid-circle-info:{ .icons } [APD and ADX](http://j.mp/TB-2014-005) 
+### [:fontawesome-solid-circle-info:{ .icons } APD and ADX](http://j.mp/TB-2014-005) 
 Provides background and contextual information related to SMPTE ST 2065-2:2012 and SMPTE ST 2065-3:2012.
 
 ----------------
 
-SMPTE Standards
+SMPTE Standards   {#smpte}
 ----------------
 
 Below are the ACES-related standards documents published through SMPTE to date. Those wishing to implement ACES should adhere to the SMPTE standards. These must be purchased in order to view.
 
-### :fontawesome-solid-file:{ .icons } [ACES Encoding](https://ieeexplore.ieee.org/servlet/opac?punumber=7289893) 
-SMPTE ST 2065-1 - Academy Color Encoding Specification
+### [:fontawesome-solid-file:{ .icons } SMPTE ST 2065-1 - Academy Color Encoding Specification](https://ieeexplore.ieee.org/servlet/opac?punumber=7289893) 
 
-### :fontawesome-solid-file:{ .icons } [Academy Printing Density (APD)](https://ieeexplore.ieee.org/servlet/opac?punumber=7292041) 
-SMPTE ST 2065-2 - Academy Printing Density (APD) — Spectral Responsivities, Reference Measurement Device and Spectral Calculation
+### [:fontawesome-solid-file:{ .icons } SMPTE ST 2065-2 - Academy Printing Density (APD) — Spectral Responsivities, Reference Measurement Device and Spectral Calculation](https://ieeexplore.ieee.org/servlet/opac?punumber=7292041) 
 
-### :fontawesome-solid-file:{ .icons } [Academy Density Exchange (ADX)](https://ieeexplore.ieee.org/servlet/opac?punumber=7291492) 
-SMPTE ST 2065-3 - Academy Density Exchange Encoding (ADX) — Encoding Academy Printing Density (APD) Values
+### [:fontawesome-solid-file:{ .icons } SMPTE ST 2065-3 - Academy Density Exchange Encoding (ADX) — Encoding Academy Printing Density (APD) Values](https://ieeexplore.ieee.org/servlet/opac?punumber=7291492) 
 
-### :fontawesome-solid-file:{ .icons } [ACES Image Container (OpenEXR)](https://ieeexplore.ieee.org/servlet/opac?punumber=7290439) 
-SMPTE ST 2065-4 - ACES Image Container File Layout
+### [:fontawesome-solid-file:{ .icons } SMPTE ST 2065-4 - ACES Image Container File Layout](https://ieeexplore.ieee.org/servlet/opac?punumber=7290439) 
 
-### :fontawesome-solid-file:{ .icons } [ACES with Material Exchange Format (MXF)](https://ieeexplore.ieee.org/servlet/opac?punumber=7748436) 
-SMPTE ST 2065-5 - Material Exchange Format — Mapping ACES Image Sequences into the MXF Generic Container
+### [:fontawesome-solid-file:{ .icons } SMPTE ST 2065-5 - Material Exchange Format — Mapping ACES Image Sequences into the MXF Generic Container](https://ieeexplore.ieee.org/servlet/opac?punumber=7748436) 
 
-### :fontawesome-solid-file:{ .icons } [ACES with Interoperable Master Format (IMF)](https://ieeexplore.ieee.org/document/8320049) 
-SMPTE ST 2067-50 - SMPTE Standard - Interoperable Master Format — Application #5 ACES
+### [:fontawesome-solid-file:{ .icons } SMPTE ST 2067-50 - SMPTE Standard - Interoperable Master Format — Application #5 ACES](https://ieeexplore.ieee.org/document/8320049)
 
-### :fontawesome-solid-file:{ .icons } [ADX Image Container (DPX)](https://ieeexplore.ieee.org/servlet/opac?punumber=7291018) 
-SMPTE ST 268:2014 – File Format for Digital Moving Picture Exchange (DPX) – Amendment 1
+### [:fontawesome-solid-file:{ .icons } SMPTE ST 268:2014 – File Format for Digital Moving Picture Exchange (DPX) – Amendment 1](https://ieeexplore.ieee.org/servlet/opac?punumber=7291018) 
+
 
 <!-- Page specific styles -->
 <style>

--- a/mkdocs/docs/specifications/acescct/index.md
+++ b/mkdocs/docs/specifications/acescct/index.md
@@ -1,0 +1,260 @@
+<!-- Include acronyms-->
+--8<-- "mkdocs/includes/acronyms.md"
+
+<!-- Include section numbering -->
+<style>
+    @import "../../stylesheets/sections.css"
+</style>
+
+
+
+ACEScct – A Quasi-Logarithmic Encoding of ACES Data for use within Color Grading Systems
+========================================================================================
+
+
+Introduction 
+----------------
+The Academy Color Encoding Specification (ACES) defines a common color encoding method using half- precision floating point values corresponding to linear exposure values encoded relative to a fixed set of extended-gamut RGB primaries. Many digital-intermediate color grading systems have been engineered assuming image data with primaries similar to the grading display and a logarithmic relationship between relative scene exposures and image code values.
+
+This document describes a 32-bit single precision floating-point logarithm encoding of ACES known as ACEScct.
+
+ACEScct uses values above 1.0 and below 0.0 to encode the entire range of ACES values. ACEScct values should not be clamped except as part of color correction needed to produce a desired artistic intent.
+
+There is no image file container format specified for use with ACEScct as the encoding is intended to be transient and internal to software or hardware systems, and is specifically not intended for interchange or archiving.
+
+For ACES values greater than 0.0078125, the ACEScct encoding function is identical to the pure-log encoding function of ACEScc. Below this point, the addition of a ”toe” results in a more distinct ”milking” or ”fogging” of shadows when a lift operation is applied when compared to the same operation applied in ACEScc. This difference in grading behavior is provided in response to colorist requests for behavior more similar to that of traditional legacy log film scan encodings.
+
+
+Scope
+-----
+This document describes a 32-bit floating point encoding of ACES for use within color grading systems.
+
+Equivalent functions may be used for implementation purposes as long as correspondence of grading param- eters to this form of log implementation is properly maintained. This document is intended as a guideline to aid developers who are integrating an ACES workflow into a color correction system.
+
+
+References
+----------
+The following standards, specifications, articles, presentations, and texts are referenced in this text:
+
+* [ST 2065-1:2021 - SMPTE Standard - Academy Color Encoding Specification (ACES)](https://doi.org/10.5594/SMPTE.ST2065-1.2021)
+* [RP 177:1993 - SMPTE Recommended Practice - Derivation of Basic Television Color Equations](https://doi.org/10.5594/SMPTE.RP177.1993)
+
+
+Specification
+-------------
+
+### Naming conventions
+The quasi-logarithmic encoding of ACES specified [below](#acescct) shall be known as ACEScct.
+
+### Color component value encoding
+ACEScct values are encoded as 32-bit floating-point numbers. This floating-point encoding uses 32 bits per component as described in IEEE 754.
+
+### Color space chromaticities {#color-space}
+ACEScct uses a different set of primaries than ACES RGB primaries defined in SMPTE ST 2065-1. The CIE 1931 colorimetry of the ACEScct RGB primaries and white are specified below.
+
+#### Color primaries
+The chromaticity values of the RGB primaries (known as AP1) shall be those found below:
+
+<div align="center" markdown>
+|       | **R** | **G** | **B** |   | **CIE x** | **CIE y** |
+|-------|-------|-------|-------|---|-----------|-----------|
+| Red   |  1.0  |  0.0  |  0.0  |   |   0.713   |   0.293   |
+| Green |  0.0  |  1.0  |  0.0  |   |   0.165   |   0.830   |
+| Blue  |  0.0  |  0.0  |  1.0  |   |   0.128   |   0.044   |
+</div>
+
+<figcaption align="center">
+    ACEScct RGB primaries chromaticity values
+</figcaption> 
+
+#### White point
+The white point shall be:
+
+<div align="center" markdown>
+|       | **R** | **G** | **B** |   | **CIE x** | **CIE y** |
+|-------|-------|-------|-------|---|-----------|-----------|
+| White |  1.0  |  1.0  |  1.0  |   |  0.32168  |  0.33767  |
+</div>
+
+<figcaption align="center">
+    ACEScct RGB white point chromaticity values
+</figcaption>
+
+### ACEScct {#acescct}
+The following functions shall be used to convert between ACES values, encoded according to SMPTE ST 2065-1, and ACEScct.
+
+#### Encoding Function
+ACES $R$, $G$, and $B$ values shall be converted to $lin_{AP1}$ $R$, $G$, and $B$ values using the transformation matrix ($TRA_1$) calculated and applied using the methods provided in Section 4 of SMPTE RP 177:1993.
+
+$lin_{AP1}$ $R$, $G$, and $B$ values shall be converted to ACEScct values according to [Equation 1](#eq-1).
+
+<a name="eq-1"></a>
+
+\begin{equation} 
+    ACEScct = \left\{ 
+    \begin{array}{l l }
+        10.5402377416545 \times lin_{AP1} + 0.0729055341958355;    & \quad lin_{AP1} \leq 0.0078125 \\[10pt]
+        \dfrac{\log_{2}(lin_{AP1}) + 9.72}{17.52}; & \quad lin_{AP1} > 0.0078125 \\    
+    \end{array} \right.
+\end{equation}
+
+<figcaption align="center">
+    <b>Equation 1:</b> Linear AP1 to ACEScct
+</figcaption>
+
+[Equation 2](#eq-2) shows the relationship between ACES $R$, $G$, and $B$ values and $lin_{AP1}$ $R$, $G$, and $B$ values. $TRA_{1}$, rounded to 10 significant digits, is derived from the product of $NPM_{AP1}$ inverse and $NPM_{AP0}$ calculated using methods provided in Section 3.3 of SMPTE RP 177:1993.<br>
+AP0 are the primaries of ACES specified in SMPTE ST 2065-1.<br>
+AP1 are the primaries of ACEScct specified in [Color space chromaticities](#color-space).
+
+<a name="eq-2"></a>
+
+\begin{equation} 
+\begin{bmatrix}
+    R_{lin_{AP1}}\\
+    G_{lin_{AP1}}\\
+    B_{lin_{AP1}}
+\end{bmatrix}
+=
+TRA_{1}
+\cdot
+\begin{bmatrix}
+    R_{ACES}\\
+    G_{ACES}\\
+    B_{ACES}
+\end{bmatrix} \\
+\end{equation}
+
+\begin{equation}
+TRA_{1} =
+\begin{bmatrix}
+    \phantom{-}1.4514393161 & -0.2365107469 & -0.2149285693 \\
+   -0.0765537734 &  \phantom{-}1.1762296998 & -0.0996759264 \\
+    \phantom{-}0.0083161484 & -0.0060324498 &  \phantom{-}0.9977163014 \\
+\end{bmatrix} \\
+\end{equation}
+
+\begin{equation}
+TRA_{1} = NPM^{-1}_{AP1} \cdot NPM_{AP0}
+\end{equation}
+
+<figcaption align="center"> 
+    <b>Equation 2:</b> ACES to linear AP1
+</figcaption>
+
+#### Decoding Function
+ACEScct $R$, $G$, and $B$ values shall be converted to $lin_{AP1}$ values using [Equation 3](#eq-3).
+
+<a name="eq-3"></a>
+
+\begin{equation}
+    lin_{AP1} = \left\{ 
+    \begin{aligned}
+        &\dfrac{\left(ACEScct-0.0729055341958355\right)}{10.5402377416545};& ACEScct& \leq 0.155251141552511 \\[10pt]
+        &2^{(ACEScct \times 17.52-9.72)}; &0.155251141552511 \leq ACEScct& < \dfrac{\log_{2}(65504)+9.72}{17.52} \\[10pt]
+        &65504; & ACEScct& \geq \dfrac{\log_{2}(65504)+9.72}{17.52} \\    
+    \end{aligned} \right.
+\end{equation}
+
+<figcaption align="center">
+    <b>Equation 3:</b> ACEScct to linear AP1
+</figcaption>
+
+$lin_{AP1}$ $R$, $G$, and $B$ values shall be converted to ACES $R$, $G$, and $B$ values using the transformation matrix ($TRA_{2}$) calculated and applied using the methods provided in Section 4 of SMPTE RP 177:1993.
+
+[Equation 4](#eq-4) shows the relationship between ACES $R$, $G$, and $B$ values and ACEScct $R$, $G$, and $B$ values. $TRA_{2}$, rounded to 10 significant digits, is derived from the product of $NPM_{AP0}$ inverse and $NPM_{AP1}$ calculated using methods provided in Section 3.3 of SMPTE RP 177:1993.<br>
+AP0 are the primaries of ACES specified in SMPTE ST 2065-1.<br>
+AP1 are the primaries of ACEScct specified in [Color space chromaticities](#color-space).
+
+<a name="eq-4"></a>
+
+\begin{equation} 
+    \begin{bmatrix}
+        R_{ACES}\\
+        G_{ACES}\\
+        B_{ACES}
+    \end{bmatrix}
+    =
+    TRA_{2}
+    \cdot
+    \begin{bmatrix}
+        R_{lin_{AP1}}\\
+        G_{lin_{AP1}}\\
+        B_{lin_{AP1}}
+    \end{bmatrix}
+\end{equation}
+
+\begin{equation}
+    TRA_{2} =
+    \begin{bmatrix}
+        \phantom{-}0.6954522414 & 0.1406786965 & 0.1638690622 \\
+        \phantom{-}0.0447945634 & 0.8596711185 & 0.0955343182 \\
+        -0.0055258826 & 0.0040252103 & 1.0015006723 \\
+    \end{bmatrix}
+\end{equation}
+
+\begin{equation}
+    TRA_{2} = NPM^{-1}_{AP1} \cdot NPM_{AP0}
+\end{equation}
+
+<figcaption align="center">
+    <b>Equation 4:</b> Linear AP1 to ACES
+</figcaption>
+
+
+Appendices
+----------
+
+
+### Appendix A: Application of ASC CDL parameters to ACEScct image data
+
+American Society of Cinematographers Color Decision List (ASC CDL) slope, offset, power, and saturation modifiers can be applied directly to ACEScct image data. To preserve the extended range of ACEScct values, no limiting function should be applied with ASC CDL parameters. The power function, however, should not be applied to any negative ACEScct values after slope and offset are applied. Slope, offset, and power are applied with the following function.
+
+!!! note
+    ACEScct is not compatible with ASC CDL values generated on-set using the ACESproxy encoding. If there is a need to reproduce a look generated on-set where ACESproxy was used, ACEScc must be used in the dailies and/or DI environment to achieve a match.
+
+\begin{equation}
+    ACEScct_{out} = \left\{ 
+    \begin{array}{l r }
+        ACEScct_{in} \times slope + offset; & \quad ACEScct_{slopeoffset} \leq 0 \\
+        (ACEScct_{in} \times slope + offset)^{power}; & \quad ACEScct_{slopeoffset} > 0 \\
+    \end{array} \right. \\ 
+\end{equation}
+
+\begin{equation}
+    \begin{array}{l}
+    \text{Where:}\\
+    ACEScct_{slopeoffset} = ACEScct_{in} \times slope + offset
+    \end{array}
+\end{equation}
+
+ASC CDL Saturation is also applied with no limiting function:
+
+\begin{gather*}
+    luma = 0.2126 \times ACEScct_{red} + 0.7152 \times ACEScct_{green} + 0.0722 \times ACEScct_{blue} \\
+    \begin{aligned}
+        ACEScct_{red} &= luma + saturation \times (ACEScct_{red} - luma) \\
+        ACEScct_{green} &= luma + saturation \times (ACEScct_{green} - luma) \\        
+        ACEScct_{blue} &= luma + saturation \times (ACEScct_{blue} - luma) \\ 
+    \end{aligned}
+\end{gather*}
+
+
+### Appendix B: Reference ACES and ACEScct values
+
+The table below contains a series of reference ACES values and the corresponding ACEScct values for developers who wish to validate the accuracy of their implementation.
+
+<div align="center" markdown>
+
+|        **Description**        |                   **ACES (R,G,B)**                   |             **ACEScct (R,G,B)**             |
+|-----------------------------:|:----------------------------------------------------|:-------------------------------------------|
+| ACES min non-zero ($2^{-24}$) | 0.000000059605,<br>0.000000059605,<br>0.000000059605 | 0.072906162,<br>0.072906162,<br>0.072906162 |
+|          ACES middle gray 18% | 0.18,<br>0.18,<br>0.18                               | 0.4135884,<br>0.4135884,<br>0.4135884       |
+|                      ACES max | 65504,<br>65504,<br>65504                            | 1.4679964,<br>1.4679964,<br>1.4679964       |
+|             ColorChecker Blue | 0.08731,<br>0.07443,<br>0.27274                      | 0.30893773,<br>0.31394949,<br>0.44770345    |
+|            ColorChecker Green | 0.15366,<br>0.25692,<br>0.09071                      | 0.39450300,<br>0.45037864,<br>0.35672542    |
+|              ColorChecker Red | 0.21743,<br>0.07070,<br>0.05130                      | 0.45224438,<br>0.32502256,<br>0.31222500    |
+|           ColorChecker Yellow | 0.58921,<br>0.53944,<br>0.09157                      | 0.52635207,<br>0.50997715,<br>0.35921441    |
+|          ColorChecker Magenta | 0.30904,<br>0.14818,<br>0.27426                      | 0.46941309,<br>0.38243160,<br>0.44857958    |
+|             ColorChecker Cyan | 0.14900,<br>0.23377,<br>0.35939                      | 0.35056940,<br>0.43296115,<br>0.47029844    |
+
+</div>

--- a/mkdocs/docs/specifications/clf/index.md
+++ b/mkdocs/docs/specifications/clf/index.md
@@ -1069,10 +1069,10 @@ The ASC CDL equations are designed to work on an input domain of floating-point 
     The nominal value is 1.0.
 
 !!! note
-If either element is not specified, values  should default to the nominal values for each element. If using the `"noClamp"` style, the result of the defaulting to the nominal values is a no-op.
+    If either element is not specified, values  should default to the nominal values for each element. If using the `"noClamp"` style, the result of the defaulting to the nominal values is a no-op.
 
 !!! note
-The structure of this `ProcessNode` matches the structure of the XML format described in the v1.2 ASC CDL specification. However, unlike the ASC CDL XML format, there are no alternate spellings allowed for these elements.
+    The structure of this `ProcessNode` matches the structure of the XML format described in the v1.2 ASC CDL specification. However, unlike the ASC CDL XML format, there are no alternate spellings allowed for these elements.
 
 The math for `style="Fwd"` is:
 

--- a/mkdocs/docs/specifications/clf/index.md
+++ b/mkdocs/docs/specifications/clf/index.md
@@ -1,13 +1,3 @@
-<!-- Include acronyms-->
---8<-- "mkdocs/includes/acronyms.md"
-
-<!-- Include section numbering -->
-<style>
-    @import "../../stylesheets/sections.css"
-</style>
-
-
-
 Common LUT Format (CLF) - A Common File Format for Look-Up Tables
 ================
 
@@ -43,17 +33,17 @@ Specification
 ### General
 A Common LUT Format (CLF) file shall be written using Extensible Markup Language (XML) and adhere to a defined XML structure. A CLF file shall have the file extension '`.clf`'.
 
-The top level element in a CLF file defines a `ProcessList` which represents a sequential set of color trans- formations. The result of each individual color transformation feeds into the next transform in the list to create a daisy chain of transforms.
+The top level element in a CLF file defines a `ProcessList` which represents a sequential set of color transformations. The result of each individual color transformation feeds into the next transform in the list to create a daisy chain of transforms.
 
-An application reads a CLF file and initializes a transform engine to perform the operations in the list. The transform engine reads as input a stream of code values of pixels, performs the calculations and/or interpola- tions, and writes an output stream representing a new set of code values for the pixels.
+An application reads a CLF file and initializes a transform engine to perform the operations in the list. The transform engine reads as input a stream of code values of pixels, performs the calculations and/or interpolations, and writes an output stream representing a new set of code values for the pixels.
 
-In the sequence of transformations described by a `ProcessList`, each `ProcessNode` performs a trans- form on a stream of pixel data, and only one input line (input pixel values) may enter a node and only one output line (output pixel values) may exit a node. A `ProcessList` may be defined to work on either 1- component or 3-component pixel data, however all transforms in the list must be appropriate, especially in the 1-component case (black-and-white) where only 1D LUT operations are allowed. Implementation may process 1-component transforms by applying the same processing to R, G, and B.
+In the sequence of transformations described by a `ProcessList`, each `ProcessNode` performs a transform on a stream of pixel data, and only one input line (input pixel values) may enter a node and only one output line (output pixel values) may exit a node. A `ProcessList` may be defined to work on either 1- component or 3-component pixel data, however all transforms in the list must be appropriate, especially in the 1-component case (black-and-white) where only 1D LUT operations are allowed. Implementation may process 1-component transforms by applying the same processing to R, G, and B.
 
 
-<figure markdown>
+<figure align="center" markdown>
   ![ProcessList](./images/processList-dark.png#only-dark){ width="350" }
   ![ProcessList](./images/processList-light.png#only-light){ width="350" }
-  <figcaption><br>Figure 1. Example of a ProcessList containing a sequence of multiple ProcessNodes</figcaption>
+  <figcaption><b>Figure 1.</b> Example of a ProcessList containing a sequence of multiple ProcessNodes</figcaption>
 </figure>
 
 The file format does not provide a mechanism to assign color transforms to either image sequences or image regions. However, the XML structure defining the LUT transform, a ProcessList, may be encapsulated in a larger XML structure potentially providing that mechanism. This mechanism is beyond the scope of this document.
@@ -152,7 +142,7 @@ The `ProcessList` is the root element for any CLF file and is composed of one or
 The `compCLFversion` corresponding to this version of the specification is be `"3.0"`.
 
 `name` (optional)
-: a concise string used as a text name of the `ProcessList` for display or selection from an applica- tion’s user interface
+: a concise string used as a text name of the `ProcessList` for display or selection from an application’s user interface
 
 `inverseOf` (optional)
 : a string for linking to another ProcessList `id` (unique) which is the inverse of this one
@@ -389,7 +379,7 @@ ponents. The first three values define the dimensions of the LUT and if multipli
     </Array>
 </LUT3D>
 ```
-<figure markdown="1">
+<figure markdown="1" align="center">
   <figcaption>Example 2 – Example of a simple LUT3D</figcaption>
 </figure>
 
@@ -973,7 +963,7 @@ If `style` is any of the “monCurve” types, then `exponent` and `offset` are 
     `"channel"` (optional)
     : the color channel to which the exponential function is applied. <br>
     Possible values are `"R"`, `"G"`, `"B"`. <br>
-    If this attribute is utilized to target different adjustments per channel, up to three `ExponentParams` elements may be used, provided that `"channel"` is set differently in each. If this attribute is not otherwise specified, the exponential function is applied identi- cally to all three color channels.
+    If this attribute is utilized to target different adjustments per channel, up to three `ExponentParams` elements may be used, provided that `"channel"` is set differently in each. If this attribute is not otherwise specified, the exponential function is applied identically to all three color channels.
 
 
 *Examples:*
@@ -1066,7 +1056,7 @@ The ASC CDL equations are designed to work on an input domain of floating-point 
     The nominal value is 0.0 for all channels.
 
     `Power`
-    : three decimal values representing the R, G, and B power values, which change the inter- mediate shape of the transfer function <br>
+    : three decimal values representing the R, G, and B power values, which change the intermediate shape of the transfer function <br>
     Valid values for power must be greater than zero ($\gt$ 0). <br>
     The nominal value is 1.0 for all channels.
 
@@ -1156,7 +1146,7 @@ Implementation Notes
 All processing shall be performed using 32-bit floating-point values. The values of the `inBitDepth` and `outBitDepth` attributes shall not affect the quantization of color values.
 
 !!! note
-    For some hardware devices, 32-bit float processing might not be possible. In such instances, process- ing should be performed at the highest precision available. Because CLF permits complex series of discrete operations, CLF LUT files are unlikely to run on hardware devices without some form of pre-processing. Any pre-processing to prepare a CLF for more limited hardware applications should adhere to the processing precision requirements.
+    For some hardware devices, 32-bit float processing might not be possible. In such instances, processing should be performed at the highest precision available. Because CLF permits complex series of discrete operations, CLF LUT files are unlikely to run on hardware devices without some form of pre-processing. Any pre-processing to prepare a CLF for more limited hardware applications should adhere to the processing precision requirements.
 
 #### Input To and Output From a ProcessList {#in-out-processlist}
 Applications often support multiple pixel formats (e.g. 8i, 10i, 16f, 32f, etc.). Often the actual pixel format to be processed may not agree with the `inBitDepth` of the first ProcessNode or the `outBitDepth` of the last ProcessNode. (Note that the `ProcessList` element itself does not contain global `inBitDepth` or `outBitDepth` attributes.) Therefore, in some cases an application may need to rescale a given `ProcessNode` to be appropriate for the actual image data being processed.
@@ -1201,7 +1191,7 @@ If, due to hardware or software limitations, a particular element or attribute i
 ### Efficient Processing
 The transform engine may merge some ProcessNodes in order to obtain better performance. For example, adjacent `Matrix` operators may be combined into a single matrix. However, in general, combining operators in a way that preserves accuracy is difficult and should be avoided.
 
-Hardware implementations may need to convert all ProcessNodes into some other form that is consistent with what the hardware supports. For example, all ProcessNodes might need to be combined into a single 3D LUT. Using a grid size of 64 or larger is recommended to preserve as much accuracy as possible. Imple- mentors should be aware that the success of such approximations varies greatly with the nature of the input and output color spaces. For example, if the input color space is scene-linear in nature, it may be necessary to use a “shaper LUT” or similar non-linearity before the 3D LUT in order to convert values into a more perceptually uniform representation.
+Hardware implementations may need to convert all ProcessNodes into some other form that is consistent with what the hardware supports. For example, all ProcessNodes might need to be combined into a single 3D LUT. Using a grid size of 64 or larger is recommended to preserve as much accuracy as possible. Implementors should be aware that the success of such approximations varies greatly with the nature of the input and output color spaces. For example, if the input color space is scene-linear in nature, it may be necessary to use a “shaper LUT” or similar non-linearity before the 3D LUT in order to convert values into a more perceptually uniform representation.
 
 ### Extensions
 It is recommended that implementors of CLF file readers protect against unrecognized elements or attributes that are not defined in this specification. Unrecognized elements that are not children of the `Info` element should either raise an error or at least provide a warning message to the user to indicate that there is an operator present that is not recognized by the reader. Applications that need to add custom metadata should place it under the `Info` element rather than at the top level of the ProcessList.
@@ -1305,8 +1295,9 @@ Appendices
 
 When an input value falls between sampled positions in a LUT, the output value must be calculated as a proportion of the distance along some function that connects the nearest surrounding values in the LUT. There are many different types of interpolation possible, but only three types of interpolation are currently specified for use with the Common LUT Format (CLF). 
 
-The first type - linear interpolation - is specified for use with a `LUT1D` node. The other two - trilinear and tetrahedral interpolation - are specified for use with a `LUT3D` node.
+The first interpolation type, [linear](#lin-interp), is specified for use with a `LUT1D` node. The other two, [trilinear](#trilinear-interp) and [tetrahedral](#tetrahedral-interp) interpolation, are specified for use with a `LUT3D` node.
 
+<a name="lin-interp"></a>
 #### Linear Interpolation
 With a table of the sampled input values in $inValue[i]$ where $i$ ranges from $0$ to $(n-1)$, and a table of the corresponding output values in $outValue[j]$ where $j$ is equal to $i$,
 
@@ -1324,6 +1315,7 @@ $$
 output = \dfrac{input-inValue[i]}{inValue[i+1]-inValue[i]} \times (outValue[j+1]-outValue[j])+outValue[j]
 $$
 
+<a name="trilinear-interp"></a>
 #### Trilinear Interpolation
 Trilinear interpolation implements linear interpolation in three-dimensions by successively interpolating each direction. 
 
@@ -1424,6 +1416,7 @@ Trilinear interpolation shall be done according to $V(r,g,b) = \mathbf{C}^T \mat
     4. Return \(V(r,g,b) = \mathbf{C}^T \mathbf{\Delta}\)
 
 
+<a name="tetrahedral-interp"></a>
 #### Tetrahedral Interpolation}
 Tetrahedral interpolation subdivides the cubelet defined by the vertices surrounding a sampled point into six tetrahedra by segmenting along the main (and usually neutral) diagonal (Figure 5). 
 
@@ -1570,3 +1563,15 @@ The parameters for the `LogParams` element are then:
 * `IndexMaps` removed. Use a `halfDomain` LUT to achieve reshaping of input to a LUT.
 * Move `ACEStransform` elements to `Info` element of ProcessList in main spec
 * Changed syntax for `dim` attribute of `Array` when contained in a `Matrix`. Two integers are now used to define the dimensions of the matrix instead of the previous three values which defined the dimensions of the matrix and the number of color components.
+
+
+
+
+
+<!-- Include acronyms-->
+--8<-- "mkdocs/includes/acronyms.md"
+
+<!-- Include section numbering -->
+<style>
+    @import "../../stylesheets/sections.css"
+</style>

--- a/mkdocs/docs/specifications/clf/index.md
+++ b/mkdocs/docs/specifications/clf/index.md
@@ -113,10 +113,10 @@ Different end of line conventions, including `<CR>`, `<LF>`, and `<CRLF>`, are u
 XML Elements {#xml-elements}
 ----------------------------
 
-<figure markdown>
+<figure align="center" markdown="1">
   ![ProcessList](./images/clf-diagram-light.png#only-light)
   ![ProcessList](./images/clf-diagram-dark.png#only-dark)
-    <figcaption><br>Figure 2. Object Model of XML Elements</figcaption>
+    <figcaption><b>Figure 2.</b> Object Model of XML Elements</figcaption>
 </figure>
 
 
@@ -321,9 +321,9 @@ Linear interpolation shall be used for `LUT1D`. More information about linear in
     </Array>
 </LUT1D>
 ```
-<figure markdown="1">
-  <figcaption>Example 1 - Example of a very simple LUT1D </figcaption>
-</figure>
+<figcaption align="center" markdown="1">
+  <b>Example 1.</b> Example of a very simple `LUT1D`
+</figcaption>
 
 
 
@@ -379,9 +379,9 @@ ponents. The first three values define the dimensions of the LUT and if multipli
     </Array>
 </LUT3D>
 ```
-<figure markdown="1" align="center">
-  <figcaption>Example 2 – Example of a simple LUT3D</figcaption>
-</figure>
+<figcaption align="center" markdown="1">
+  <b>Example 2.</b> Example of a simple `LUT3D`
+</figcaption>
 
 
 
@@ -498,9 +498,9 @@ $$
     </Array>
 </Matrix>
 ```
-<figure markdown="1">
-  <figcaption>Example 3 – Example of a <code>Matrix</code> node with <code>dim="3 3 3"</code></figcaption>
-</figure>
+<figcaption align="center" markdown="1">
+  <b>Example 3.</b> Example of a `Matrix` node with `dim="3 3 3"`
+</figcaption>
 
 ```xml
 <Matrix id="lut-25" name="colorspace conversion" inBitDepth="10i" outBitDepth="10i" >
@@ -512,9 +512,9 @@ $$
     </Array>
 </Matrix>
 ```
-<figure markdown="1">
-  <figcaption>Example 4 – Example of a <code>Matrix</code> node</figcaption>
-</figure>
+<figcaption align="center" markdown="1">
+  <b>Example 4.</b> Example of a `Matrix` node
+</figcaption>
 
 
 
@@ -527,26 +527,28 @@ Unless otherwise specified, the node’s default behavior is to scale and offset
 
 To achieve scale and/or offset of values, all of `minInValue`, `minOutValue`, `maxInValue`, and `maxOutValue` must be present. In this explicit case, the formula for `Range` shall be: 
 
+<a name="eq-range"></a>
+
 $$
     out = in \times scale + \texttt{minOutValue} - \texttt{minInValue} \times scale
 $$
 
-where:
-$$
-    scale = \dfrac{(\texttt{maxOutValue} - \texttt{minOutValue})}{(\texttt{maxInValue} - \texttt{minInValue})}
-$$
+where: <br>
+<center>$scale = \dfrac{(\texttt{maxOutValue} - \texttt{minOutValue})}{(\texttt{maxInValue} - \texttt{minInValue})}$</center>
 
 The scaling of `minInValue` and `maxInValue` depends on the input bit-depth, and the scaling of `minOutValue` and `maxOutValue` depends on the output bit-depth.
 
 If `style="Clamp"`, the output value of $out$ from the above equation is furthur modified as follows:
+
+<a name="eq-range-2"></a>
 
 $$
     out_{clamped} = \mathrm{MIN}(\texttt{maxOutValue}, \mathrm{MAX}( \texttt{minOutValue}, out))
 $$
 
 where: <br>
-$\mathrm{MAX}(a,b)$ returns $a$ if $a > b$ and $b$ if $b \geq a$<br>
-$\mathrm{MIN}(a,b)$ returns $a$ if $a < b$ and $b$ if $b \leq a$
+<center>$\mathrm{MAX}(a,b)$ returns $a$ if $a > b$ and $b$ if $b \geq a$<br>
+$\mathrm{MIN}(a,b)$ returns $a$ if $a < b$ and $b$ if $b \leq a$</center>
 
 The `Range` element can also be used to clamp values on only the top or bottom end. In such instances, no offset is applied, and the formula simplifies because only one pair of min or max values are required. (The `style` shall not be `"noClamp"` for this use-case.)
 
@@ -579,7 +581,7 @@ $$
 In both instances, values must be set such that $\texttt{maxOutValue} = \texttt{maxInValue} \times bitDepthScale$.
 
 !!! note
-    The bit depth scale factor intentionally uses $2^{bitDepth}−1$ and not $2^{bitDepth}$. This means that the scale factor created for scaling between different bit depths is "non-integer" and is slightly different depending on the bit depths being scaled between. While instinct might be that this scale should be a clean bit-shift factor (i.e. 2x or 4x scale), testing with a few example values plugged into the formula will show that the resulting non-integer scale is the correct and intended behavior.
+    The bit depth scale factor intentionally uses $2^{bitDepth}−1$ and not $2^{bitDepth}$. This means that the scale factor created for scaling between different bit depths is "non-integer" and is slightly different depending on the bit depths being scaled between. While instinct might be that this scale should be a clean bit-shift factor (i.e. $2\times$ or $4\times$ scale), testing with a few example values plugged into the formula will show that the resulting non-integer scale is the correct and intended behavior.
 
 At least one pair of either minimum or maximum values, or all four values, must be provided.
 
@@ -605,10 +607,10 @@ The options for `style` are:
 
 <div style="padding-left: 30px;" markdown="1">
 `"noClamp"`
-: If present, scale and offset is applied without clamping, as in Eq. 4.6. (i.e. values below `minOutValue` or above `maxOutValue` are preserved)
+: If present, scale and offset is applied [without clamping](#eq-range) (i.e. values below `minOutValue` or above `maxOutValue` are preserved)
 
 `"Clamp"`
-: If present, clamping is applied according to Eq. 4.7 upon the result of the scale and offset expressed in Eq. 4.6
+: If present, [clamping](#eq-range-2) is applied upon the result of the scale and offset expressed by the result of the non-clamping `Range` equation
 </div>
 
 *Examples:*
@@ -620,9 +622,10 @@ The options for `style` are:
 <maxOutValue>940</minInValue>
 </Range>
 ```
-<figure markdown="1">
-  <figcaption>Example 5 – Using <code>"Range"</code> for scaling 10-bit full range to 10-bit SMPTE (legal) range.</figcaption>
-</figure>
+<figcaption align="center" markdown="1">
+  <b>Example 5.</b> Using `"Range"` for scaling 10-bit full range to 10-bit SMPTE (legal) range.
+</figcaption>
+
 
 
 ### `Log`
@@ -652,9 +655,11 @@ Supported values for ”style” are:
 
 : The formula to be applied for each style is described by the equations below, for all of which:
 
-    $\texttt{FLT_MIN} = 1.175494e−38$
+    $$
+    \texttt{FLT_MIN} = 1.175494e−38
+    $$
 
-    $\textrm{MAX}(a, b)$ returns $a$ if $a \gt b$ and $b$ if $b \geq a$
+    <center>$\textrm{MAX}(a, b)$ returns $a$ if $a \gt b$ and $b$ if $b \geq a$</center>
 
     - `"log10"`: applies a base 10 logarithm according to  
 
@@ -694,6 +699,8 @@ Supported values for ”style” are:
 
     - `"cameraLinToLog"`: applies a piecewise function with logarithmic and linear segments on linear values, converting them to non-linear values
 
+    <a name="eq-linToLog"></a>
+
     $$
     y = \begin{cases} 
     \text{linearSlope} \times x + \text{linearOffset} & \text{if } x \leq \text{linSideBreak}\\
@@ -701,11 +708,8 @@ Supported values for ”style” are:
     \end{cases} \\
     $$
 
-    <div style="padding-left: 90px;" markdown="1">
-    where: <br>
-    $\text{linearSlope}$ is calculated using Eq.<br>
-    $\text{linearOffset}$ is calculated using Eq.
-    </div>
+    !!! note
+        The calculation of [$\text{linearSlope}$](#eq-linearSlope), and [$\text{linearOffset}$](#eq-linearOffset) is described in [Solving for `LogParams`](#solving-logParams)
 
     - `"cameraLogToLin"`: applies a piecewise function with logarithmic and linear segments on non-linear values, converting them to linear values
 
@@ -715,12 +719,10 @@ Supported values for ”style” are:
     \end{cases}
     $$
 
-    <div style="padding-left: 90px;" markdown="1">
-    where: <br>
-    $\text{logSideBreak}$ is calculated using Eq.<br>
-    $\text{linearSlope}$ is calculated using Eq.
-    $\text{linearOffset}$ is calculated using Eq.    
-    </div>
+    !!! note
+        The calculation of [$\text{logSideBreak}$](#eq-logSideBreak), [$\text{linearSlope}$](#eq-linearSlope), and [$\text{linearOffset}$](#eq-linearOffset) is described in [Solving for `LogParams`](#solving-logParams)
+
+
 
 *Elements:*
 `LogParams` (required - if `"style"` is not a basic logarithm)
@@ -731,7 +733,7 @@ This element is required if `style` is of type `"linToLog"`, `"logToLin"`, `"cam
 
     `"base"` (optional)
     : the base of the logarithmic function <br>
-    Default is 2
+    Default is 2.
 
     `"logSideOffset"` (optional) 
     : offset applied to the log side of the logarithmic segment.<br>
@@ -755,17 +757,32 @@ This element is required if `style` is of type `"linToLog"`, `"logToLin"`, `"cam
     `"channel"` (optional)
     : the color channel to which the exponential function is applied. Possible values are `"R"`, `"G"`, `"B"`. If this attribute is utilized to target different adjustments per channel, then up to three `LogParams` elements may be used, provided that `"channel"` is set differently in each. However, the same value of base must be used for all channels. If this attribute is not otherwise specified, the logarithmic function is applied identically to all three color channels.
 
+
+<a name="solving-logParams"></a>
+
 !!! note "Solving for `LogParams`"
-    $\text{linearOffset}$ is the offset of the linear segment of the piecewise function. This value is calculated using the position of the break-point and the linear slope in order to ensure continuity of the two segments. Equations 4.18-4.20 describe the steps for calculating $\text{linearOffset}$.
-    First, the value of the break-point on the log-axis is calculated using the value of $\text{linSideBreak}$ as input to the logarithmic segment of Eq. 4.16, as shown in Eq. 4.18.
+    $\text{linearOffset}$ is the offset of the linear segment of the piecewise function. This value is calculated using the position of the break-point and the linear slope in order to ensure continuity of the two segments. The following steps describe how  to calculate $\text{linearOffset}$.
+    
+    First, the value of the break-point on the log-axis is calculated using the value of $\text{linSideBreak}$ as input to the logarithmic segment of the [piecewise function](#eq-linToLog), as below:
+    
+    <a name="eq-logSideBreak"></a>
+    
     $$
     logSideBreak = logSideSlope × logbase(linSideSlope × linSideBreak + linSideOffset) + logSideOffset
     $$
-    Then, if $\text{linearSlope}$ was not provided, the value of $\text{linSideBreak}$ is used again to solve for the derivative of Eq. 4.14. The value of $\text{linearSlope}$ is set to equal the the instantaneous slope at the break-point, or derivative which is shown being solved for by Eq. 4.19:
+    
+    Then, if $\text{linearSlope}$ was not provided, the value of $\text{linSideBreak}$ is used again to solve for the derivative of the logarithmic function. The value of $\text{linearSlope}$ is set to equal the instantaneous slope at the break-point, or derivative, as shown below:
+
+    <a name="eq-linearSlope"></a>
+
     $$ 
     \text{linearSlope} = \text{logSideSlope} \times \left(\frac{\text{linSideSlope}}{(\text{linSideSlope} \times \textbf{linSideBreak} + \text{linSideOffset}) \times \text{ln}(\text{base})}\right)
     $$
-    Finally, the value of $\text{linearOffset}$ can be solved for by rearranging the linear segment of Eq. 4.16 to get Equation 4.20 and using the values of $\text{logSideBreak|$ (obtained from Eq. 4.18) and $\text{linearSlope}$ (obtained from Eq. 4.19).
+
+    Finally, the value of $\text{linearOffset}$ can be solved for by rearranging the linear segment of of the [piecewise function](#eq-linToLog) and using the values of $\text{logSideBreak|$ and $\text{linearSlope}$
+
+    <a name="eq-linearOffset"></a>
+
     $$
     \text{linearOffset} = \textbf{logSideBreak} - \textbf{ linearSlope} \times \text{linSideBreak}
     $$
@@ -777,9 +794,10 @@ This element is required if `style` is of type `"linToLog"`, `"logToLin"`, `"cam
 </Log>
 ```
 
-<figure markdown="1">
-  <figcaption>Example 6 – Example <code>Log</code> node applying a base 10 logarithm.</figcaption>
-</figure>
+<figcaption align="center" markdown="1">
+  <b>Example 6.</b> `Log` node applying a base 10 logarithm.
+</figcaption>
+
 
 
 ```xml
@@ -791,9 +809,10 @@ This element is required if `style` is of type `"linToLog"`, `"logToLin"`, `"cam
 </Log>
 ```
 
-<figure markdown="1">
-  <figcaption>Example 7 – Example <code>Log</code> node applying the DJI D-Log formula.</figcaption>
-</figure>
+<figcaption align="center" markdown="1">
+  <b>Example 7.</b> `Log` node applying the DJI D-Log formula.
+</figcaption>
+
 
 
 ### `Exponent`
@@ -816,7 +835,7 @@ This node contains parameters for processing pixels through a power law function
     - `"monCurveMirrorFwd"`
     - `"monCurveMirrorRev"`
 
-    The formula to be applied for each style is included in Equations 4.21-4.28 for all of which:
+    Each of these supported styles are described in detail below, and for all of which the following definitions apply:
     <div style="padding-left: 150px;" markdown="1">
     $g =$ `exponent` <br>
     $k =$ `offset` <br>
@@ -883,6 +902,8 @@ This node contains parameters for processing pixels through a power law function
     `"monCurveFwd"`
     : applies a power law function with a linear segment near the origin
 
+    <a name="eq-monCurveFwd"></a>
+    
     $$
     \text{monCurveFwd}(x) = \begin{cases}
     \left( \frac{x\:+\:k}{1\:+\:k} \right)^{g} & \text{if } x \geq xBreak \\[8pt]
@@ -890,16 +911,17 @@ This node contains parameters for processing pixels through a power law function
     \end{cases}
     $$
 
-    <div style="padding-left: 220px;" markdown="1">
-    where: <br>
-    $xBreak = \dfrac{k}{g-1}$ <br>
-    and, for the above and below equations: <br>
-    $s = \left(\dfrac{g-1}{k}\right)  \left(\dfrac{k g}{(g-1)(1+k)}\right)^{g}$
-    </div>
-    
+    : where: <br>
+    <center>$xBreak = \dfrac{k}{g-1}$</center>
+
+    : and, for the $\text{monCurveFwd}$ ([above](#eq-monCurveFwd)) and $\text{monCurveRev}$ ([below](#eq-monCurveRev)) equations: <br>
+    <center>$s = \left(\dfrac{g-1}{k}\right)  \left(\dfrac{k g}{(g-1)(1+k)}\right)^{g}$</center>
+
     `"monCurveRev"`
     : applies a power law function with a linear segment near the origin
 
+    <a name="eq-monCurveRev"></a>
+        
     $$
     \text{monCurveRev}(y) = \begin{cases}
     (1 + k)\:y^{(1/g)} - k & \text{if } y \geq yBreak \\[8pt]
@@ -907,11 +929,10 @@ This node contains parameters for processing pixels through a power law function
     \end{cases}
     $$
 
-    <div style="padding-left: 220px;" markdown="1">
-    where: <br>
-    $yBreak = \left(\dfrac{k g}{(g-1)(1+k)}\right)^g$
-    </div>
-
+    : where: <br>
+    <center>$yBreak = \left(\dfrac{k g}{(g-1)(1+k)}\right)^g$</center>
+    
+    
     `"monCurveMirrorFwd"`
     : applies a power law function with a linear segment near the origin and mirrors the function for values less than zero (i.e. rotationally symmetric around the origin):
     
@@ -973,9 +994,9 @@ If `style` is any of the “monCurve” types, then `exponent` and `offset` are 
     <ExponentParams exponent="2.2"/>
 </Exponent>
 ```
-<figure markdown="1">
-  <figcaption>Example 8 – Using <code>Exponent</code> node for applying a 2.2 gamma.</figcaption>
-</figure>
+<figcaption align="center" markdown="1">
+  <b>Example 8.</b> Using `Exponent` node for applying a 2.2 gamma.
+</figcaption>
 
 
 ``` xml
@@ -984,9 +1005,9 @@ If `style` is any of the “monCurve” types, then `exponent` and `offset` are 
     <ExponentParams exponent="2.4" offset="0.055" />
 </Exponent>
 ```
-<figure markdown="1">
-  <figcaption>Example 9 – Using <code>Exponent</code> node for applying the intended EOTF found in IEC 61966-2-1:1999 (sRGB). </figcaption>
-</figure>
+<figcaption align="center" markdown="1">
+  <b>Example 9.</b> Using `Exponent` node for applying the intended EOTF found in IEC 61966-2-1:1999 (sRGB).
+</figcaption>
 
 ```xml
 <Exponent inBitDepth="32f" outBitDepth="32f" style="monCurveRev">
@@ -994,9 +1015,9 @@ If `style` is any of the “monCurve” types, then `exponent` and `offset` are 
     <ExponentParams exponent="3.0" offset="0.16" />
 </Exponent>
 ```
-<figure markdown="1">
-  <figcaption>Example 10 – Using <code>Exponent</code> node to apply CIE L* formula.</figcaption>
-</figure>
+<figcaption align="center" markdown="1">
+  <b>Example 10.</b> Using `Exponent` node to apply CIE L* formula.
+</figcaption>
 
 ``` xml
 <Exponent inBitDepth="32f" outBitDepth="32f" style="monCurveRev">
@@ -1004,9 +1025,10 @@ If `style` is any of the “monCurve” types, then `exponent` and `offset` are 
     <ExponentParams exponent="2.2222222222222222" offset="0.099" />
 </Exponent>
 ```
-<figure markdown="1">
-  <figcaption>Example 11 – Using <code>Exponent</code> node to apply Rec. 709 OETF.</figcaption>
-</figure>
+<figcaption align="center" markdown="1">
+  <b>Example 11.</b> Using `Exponent` node to apply Rec. 709 OETF.
+</figcaption>
+
 
 
 ### `ASC_CDL`
@@ -1131,9 +1153,9 @@ Also, if $out_{\textrm{SAT}} \lt 0$, then no power function is applied.
     </SatNode>
 </ASC_CDL>
 ```
-<figure markdown="1">
-  <figcaption>Example 12 – Example of an <code>ASC_CDL</code> node.</figcaption>
-</figure>
+<figcaption align="center" markdown="1">
+  <b>Example 12.</b> Example of an `ASC_CDL` node.
+</figcaption>
 
 
 
@@ -1222,9 +1244,10 @@ Examples
     </Matrix>
 </ProcessList>
 ```
-<figure markdown="1">
-  <figcaption>Example 13 – ACES2065-1 to ACEScg</figcaption>
-</figure>
+<figcaption align="center" markdown="1">
+  <b>Example 13.</b> ACES2065-1 to ACEScg
+</figcaption>
+
 
 ``` xml
 <?xml version="1.0" encoding="UTF-8"?>
@@ -1250,9 +1273,10 @@ Examples
     </Log>
 </ProcessList>
 ```
-<figure markdown="1">
-  <figcaption>Example 14 – ACES2065-1 to ACEScct</figcaption>
-</figure>
+<figcaption align="center" markdown="1">
+  <b>Example 14.</b> ACES2065-1 to ACEScct
+</figcaption>
+
 
 ``` xml
 <?xml version="1.0" encoding="UTF-8"?>
@@ -1282,9 +1306,10 @@ Examples
 </ProcessList>
 
 ```
-<figure markdown="1">
-  <figcaption>Example 15 – CIE XYZ to CIELAB</figcaption>
-</figure>
+<figcaption align="center" markdown="1">
+  <b>Example 15.</b> CIE XYZ to CIELAB
+</figcaption>
+
 
 
 
@@ -1515,7 +1540,7 @@ $$
 ### Appendix B: Cineon-style Log Parameters {#appendix-cineon-style}
 When using a `Log` node, it might be desirable to conform an existing logarithmic function that uses Cineon style parameters to the parameters used by CLF. A translation from Cineon-style parameters to those used by CLF's `LogParams` element is quite straightforward using the following steps.
 
-Traditionally, $\textrm{refWhite}$ and $\textrm{refBlack}$ are provided as 10-bit quantities, and if they indeed are, first normalize them to floating point by dividing by 1023.
+Traditionally, $\textrm{refWhite}$ and $\textrm{refBlack}$ are provided as 10-bit quantities, and if they indeed are, first normalize them to floating point by dividing by 1023:
 
 $$
 \begin{align}
@@ -1524,7 +1549,7 @@ $$
 \end{align}
 $$
 
-Where subscript 10$i$ indicates a 10-bit quantity.
+where subscript 10$i$ indicates a 10-bit quantity.
 
 The density range is assumed to be:
 


### PR DESCRIPTION
This PR:
- adds the ACEScct specification as translated to the new mkdoc system
- makes edits to the CLF Specification including:
  - fixes #8

  - fixes #9 

  - replaces numbered Eq. references from the LaTeX version with anchor links for better cross-referencing

  - fixes some broken rendering of equations

  - conforms captions on examples to the same format

  - minor formatting and typo fixes

- updates landing page

  - updates links for the new docs added

  - adds Components section 

  - makes icons next to headers clickable in addition to the header text

  - updates links to SMPTE standards to their most recent revisions
