### PR TITLE
Add link to RGC stop-gap reference implementations

### DIFF
--- a/mkdocs/docs/guides/rgc-user/index.md
+++ b/mkdocs/docs/guides/rgc-user/index.md
@@ -113,6 +113,11 @@ in to image data at the appropriate stage in the pipeline - which varies based
 on the needs of your production, as outlined in the flow chart and explained
 below.
 
+Several DCCs, and OCIOv2.1, have already implemented the Reference Gamut
+Compression natively, but for those who need to use an application or version
+without native support, various implementations are provided as a stop-gap
+solution in [this GitHub repo](https://github.com/ampas/aces-vwg-gamut-mapping-2020/tree/master/reference).
+
 
 ### On Set
 #### Live Grading


### PR DESCRIPTION
The RGC documentation had no link to the stop-gap implementations, and several people were stumbling onto earlier versions or @jedypod's repo, and believing them to be the ACES 1.3 Reference Gamut Compression. Particularly for people using versions of Nuke prior to support for OCIOv2.1, ensuring they find the correct Blink implementation is important.