### PR TITLE
Fix LaTeX errors in chroma compression doc

### DIFF
--- a/docs/output-transforms/technical-details/chroma-compression/index.md
+++ b/docs/output-transforms/technical-details/chroma-compression/index.md
@@ -26,13 +26,13 @@ The chroma compression has two main steps:
 After the tonescale has compressed J to the target display peak luminance, the M correlate must also be rescaled or compressed down to the same range. This is done by using the $\frac{1}{cz}$ exponent defined in Hellwig2022 model in order maintain the correct M to J ratio. Maintaining the correct ratio keeps the chromaticities constant. The rescaling method is the following:
 
 $$
-M_s = M\cdot\frac{J_{t}}{J}^{\frac{1}{cz}}
+M_s = M\cdot\left(\frac{J_{t}}{J}\right)^{\frac{1}{cz}}
 $$
 
 and its inverse:
 
 $$
-M = M_s\cdot\frac{J_{t}}{J}^{-\frac{1}{cz}}
+M = M_s\cdot\left(\frac{J_{t}}{J}\right)^{-\frac{1}{cz}}
 $$
 
 where,
@@ -85,15 +85,17 @@ $$
 
 where,
 
-$
+$$
 k_{1}=\sqrt{c_1^{2}+k_{2}^{2}}
-$
-$
+$$
+
+$$
 k_{2}=max(c_2, 0.001)
-$
-$
+$$
+
+$$
 k_{3}=\frac{limit+k_{1}}{limit+k_{2}}
-$
+$$
 
 The function is driven with three external parameters $limit$, $c_1$ and $c_2$ defined below.
 
@@ -106,6 +108,7 @@ The maximum distance is limited to AP1.  That is, the compression and expansion 
 $$
 limit = J_{t}^{\frac{1}{cz}}\cdot\frac{AP1ReachM[h]}{AP1CuspM[h]}
 $$
+
 where,
 
 $AP1ReachM$ is a hue dependent lookup table of AP1 M values at $J_{max}$
@@ -148,11 +151,13 @@ The $threshold$ parameter is used to reduce expansion of noise by making the toe
 $$
 expand = 1.65
 $$
+
 $$
-saturation= max(0.15,  expand - expand * 0.78 *  \log_{10}\left(\frac{Lpeak}{100}\right))
+saturation= max(0.15,  expand - expand * 0.78 *  \log_{10}\left(\frac{L_{peak}}{100}\right))
 $$
+
 $$
-threshold = \frac{0.5}{Lpeak}
+threshold = \frac{0.5}{L_{peak}}
 $$
 
 #### Compression of M
@@ -174,8 +179,9 @@ The $compression$ parameter defines how aggressive the compression is. The param
 $$
 compr = 3.5
 $$
+
 $$
-compression = compr+ compr * 5.0 * \log_{10}\left(\frac{Lpeak}{100}\right)
+compression = compr+ compr * 5.0 * \log_{10}\left(\frac{L_{peak}}{100}\right)
 $$
 
 #### Inverse of chroma compression

--- a/docs/output-transforms/technical-details/gamut-compression/index.md
+++ b/docs/output-transforms/technical-details/gamut-compression/index.md
@@ -206,7 +206,7 @@ $$
 !!! note
     The $\gamma$ values for the upper and lower parts are not necessarily the same. In the ACES 2.0 rendering, a constant value is adequate for the lower part of the gamut hull, but a varying value is needed to approximate the upper part.
 
-[This Desmos plot](https://www.desmos.com/calculator/bbyrfbbbul) shows the intersection solves, slope calculation and boundary approximation, as the source $(M, J)$ and cusp are dragged interactively.
+[This Desmos plot](https://www.desmos.com/calculator/fy6jgmigmi) shows the intersection solves, slope calculation and boundary approximation, as the source $(M, J)$ and cusp are dragged interactively.
 
 Optionally, in order to smooth the abrupt change of compression across the cusp, smoothing can be applied by finding the intersections with both the upper and lower boundary lines, and then taking a ‘[smooth minimum](https://www.desmos.com/calculator/a1uny6zrtf)’ between them. Simply using this value will round off the cusp, thus cutting into the gamut volume. In order to ensure that the smoothed approximation contains the whole true gamut, the cusp used in the boundary calculations must be moved out slightly from the actual cusp position. This ‘puffing out’ of the approximated boundary has the additional benefit that the exact value of the gamma used to approximate it is less crucial.
 


### PR DESCRIPTION
These changes fix some LaTeX equations which were not rendering properly, as well as adding extra brackets to two equations for clarity.